### PR TITLE
年度別リンクのyear-link-areaクラスに対してnowrapを設定

### DIFF
--- a/src/layouts/NewsLayout.astro
+++ b/src/layouts/NewsLayout.astro
@@ -73,6 +73,7 @@ const years = [...new Set(allPosts.map((post: any) => post.data.year))].sort(
   .year-link-area {
     max-height: 60dvh;
     overflow: auto;
+    text-wrap: nowrap;
   }
 
   .articles {


### PR DESCRIPTION
年度別リンクのボタン内テキストを折り返しなしにしたよ